### PR TITLE
Integrar recomendación de LLM en la vista de detalle de la visita

### DIFF
--- a/app/src/main/java/com/medisupply/data/models/VisitaDetalle.kt
+++ b/app/src/main/java/com/medisupply/data/models/VisitaDetalle.kt
@@ -77,5 +77,8 @@ data class VisitaDetalle(
     val productosPreferidos: List<ProductoPreferido>? = null,
 
     @SerializedName("tiempo_desplazamiento")
-    val tiempoDesplazamiento: String? = null
+    val tiempoDesplazamiento: String? = null,
+
+    @SerializedName("recomendacion_llm")
+    val recomendacionLlm: String? = null
 )

--- a/app/src/main/java/com/medisupply/ui/fragments/DetalleVisitaFragment.kt
+++ b/app/src/main/java/com/medisupply/ui/fragments/DetalleVisitaFragment.kt
@@ -208,17 +208,7 @@ class DetalleVisitaFragment : Fragment() {
         val dirLimp = limpiarDireccion(visita.direccion)
         setupFila(binding.rowDireccion, "Dirección", dirLimp)
         setupFila(binding.rowContacto, "Contacto", visita.clienteContacto ?: "N/A")
-        val productosTexto: String
-        if (visita.productosPreferidos?.isNotEmpty() == true) {
-            val builder = StringBuilder()
-            for (producto in visita.productosPreferidos) {
-                builder.append("• ${producto.nombre}\n")
-            }
-            productosTexto = builder.trim().toString()
-        } else {
-            productosTexto = "N/A"
-        }
-        setupFila(binding.rowProductos, "Sugerencia de productos:", productosTexto)
+        setupFila(binding.rowProductos, "Recomendación", visita.recomendacionLlm ?: "No disponible")
 
         // Usar el tiempo de desplazamiento de la API
         setupFila(binding.rowTiempo, "Tiempo de Desplazamiento", visita.tiempoDesplazamiento ?: "N/A")


### PR DESCRIPTION
This pull request updates how product recommendations are displayed in the visit details by switching from a manually built product list to using a new LLM-generated recommendation field. It also introduces a new property to the `VisitaDetalle` data model to support this feature.

**Feature enhancement:**

* Added a new field, `recomendacionLlm`, to the `VisitaDetalle` data model to store LLM-generated recommendations.

**UI update:**

* Updated the `DetalleVisitaFragment` to display the `recomendacionLlm` value as the product recommendation instead of building a list from `productosPreferidos`. If the LLM recommendation is unavailable, it shows "No disponible".


https://github.com/user-attachments/assets/f4dc883e-23b6-4a4a-b9ed-018b4abef46e

